### PR TITLE
:wrench: :sparkles: SQUEAK-1 - Parse simple settings yaml

### DIFF
--- a/cmd/squeak/generate/generate.go
+++ b/cmd/squeak/generate/generate.go
@@ -19,9 +19,12 @@ var GenerateCmd = cobra.Command{
 			return
 		}
 
-		fmt.Printf("sql dialect is: %d=%q\n",
+		fmt.Printf("sql dialect is: %d=%q, output type is: %d=%q\n",
 			config.Dialect,
-			cmd.Flags().Lookup("dialect").Value.String())
+			cmd.Flags().Lookup("dialect").Value.String(),
+			config.Output,
+			cmd.Flags().Lookup("output").Value.String(),
+		)
 	},
 }
 

--- a/cmd/squeak/generate/generate.go
+++ b/cmd/squeak/generate/generate.go
@@ -19,14 +19,21 @@ var GenerateCmd = cobra.Command{
 			return
 		}
 
-		fmt.Printf("sql dialect is: %d=%q, output type is: %d=%q\n",
+		if cmd.Flags().Changed("create-tables") {
+			createTables, _ := cmd.Flags().GetBool("create-tables")
+			config.CreateTables = createTables
+		}
+
+		fmt.Printf("sql dialect is: %d=%q, output type is: %d=%q, createTables: %v\n",
 			config.Dialect,
 			cmd.Flags().Lookup("dialect").Value.String(),
 			config.Output,
 			cmd.Flags().Lookup("output").Value.String(),
+			config.CreateTables,
 		)
 	},
 }
 
 func init() {
+	GenerateCmd.PersistentFlags().Bool("create-tables", false, "Generate CREATE TABLE statements")
 }

--- a/cmd/squeak/generate/generate.go
+++ b/cmd/squeak/generate/generate.go
@@ -12,8 +12,15 @@ var GenerateCmd = cobra.Command{
 	Use:   "generate",
 	Short: "Generate CREATE and INSERT statements",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		config, cast := ctx.Value("config").(*lib.Config)
+		if !cast {
+			cmd.PrintErrf("Could not get config\n")
+			return
+		}
+
 		fmt.Printf("sql dialect is: %d=%q\n",
-			lib.CurrentSQLDialect,
+			config.Dialect,
 			cmd.Flags().Lookup("dialect").Value.String())
 	},
 }

--- a/cmd/squeak/main.go
+++ b/cmd/squeak/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
 	"squeak/cmd/squeak/generate"
@@ -33,16 +34,21 @@ func main() {
 	rootCmd.PersistentFlags().String("config", "", "Path to config file")
 	_ = rootCmd.MarkFlagRequired("config")
 
+	config := lib.NewConfig()
+
 	// we accept overrides for the different settings under `generate`
-	// in the YAML file
-	// TODO(manuel): this should be moved to the RootCmd
+	// in the YAML file.
+	// TODO(manuel): The problem here is that we will override the config settings if we pass
+	// a pointer to the variable directly
 	rootCmd.PersistentFlags().VarP(
-		enumflag.New(&lib.CurrentSQLDialect, "dialect",
+		enumflag.New(&config.Dialect, "dialect",
 			SQLDialectIds, enumflag.EnumCaseInsensitive),
 		"dialect", "d",
 		"Dialect to use for the generated SQL statements")
 
 	rootCmd.AddCommand(&generate.GenerateCmd)
 
-	_ = rootCmd.Execute()
+	ctx := context.WithValue(context.TODO(), "config", lib.NewConfig())
+
+	_ = rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/squeak/main.go
+++ b/cmd/squeak/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"github.com/mattn/go-isatty"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
+	"os"
 	"squeak/cmd/squeak/generate"
 	"squeak/lib"
+	"time"
 )
 import "github.com/rs/zerolog"
 
@@ -18,6 +22,26 @@ var rootCmd = cobra.Command{
 		if debug {
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		}
+		if isatty.IsTerminal(os.Stderr.Fd()) {
+			log.Debug().Msg("stderr is a terminal")
+			log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
+		} else {
+			log.Debug().Msg("stderr is not a terminal")
+			log.Logger = log.Output(os.Stderr)
+		}
+
+		ctx := cmd.Context()
+		if ctx == nil {
+			log.Fatal().Msg("No context")
+		}
+		config, cast := ctx.Value("config").(*lib.Config)
+		if !cast {
+			log.Fatal().Msg("No config set in context")
+		}
+
+		if cmd.Flags().Lookup("dialect") != nil {
+			config.Dialect = overrideSQLDialect
+		}
 	},
 }
 
@@ -26,6 +50,7 @@ var SQLDialectIds = map[lib.SQLDialect][]string{
 	lib.MySQL:      {"mysql"},
 	lib.PostGreSQL: {"postgresql"},
 }
+var overrideSQLDialect lib.SQLDialect = lib.SQLite
 
 func main() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -34,14 +59,9 @@ func main() {
 	rootCmd.PersistentFlags().String("config", "", "Path to config file")
 	_ = rootCmd.MarkFlagRequired("config")
 
-	config := lib.NewConfig()
-
-	// we accept overrides for the different settings under `generate`
-	// in the YAML file.
-	// TODO(manuel): The problem here is that we will override the config settings if we pass
-	// a pointer to the variable directly
+	// we accept overrides for the different settings in the YAML file
 	rootCmd.PersistentFlags().VarP(
-		enumflag.New(&config.Dialect, "dialect",
+		enumflag.New(&overrideSQLDialect, "dialect",
 			SQLDialectIds, enumflag.EnumCaseInsensitive),
 		"dialect", "d",
 		"Dialect to use for the generated SQL statements")
@@ -49,6 +69,5 @@ func main() {
 	rootCmd.AddCommand(&generate.GenerateCmd)
 
 	ctx := context.WithValue(context.TODO(), "config", lib.NewConfig())
-
 	_ = rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/squeak/main.go
+++ b/cmd/squeak/main.go
@@ -21,7 +21,9 @@ func loadConfigFile(path string) (*lib.ConfigFile, error) {
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Could not open config file %s", path)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	bytes, err := ioutil.ReadAll(file)
 	if err != nil {
@@ -64,10 +66,7 @@ var rootCmd = cobra.Command{
 			log.Fatal().Msg("No config set in context")
 		}
 
-		if cmd.Flags().Lookup("dialect") != nil {
-			config.Dialect = overrideSQLDialect
-		}
-
+		// parse config file
 		configValue := cmd.Flags().Lookup("config").Value
 		if configValue == nil || configValue.String() == "" {
 			log.Fatal().Msg("No config file given")
@@ -77,6 +76,13 @@ var rootCmd = cobra.Command{
 			log.Fatal().Err(err).Msg("Could not load config file")
 		}
 		config.FromConfigFile(configFile)
+
+		// handle overrides
+		dialectValue := cmd.Flags().Lookup("dialect")
+		if dialectValue != nil {
+			config.Dialect = overrideSQLDialect
+		}
+
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("squeak")

--- a/cmd/squeak/main.go
+++ b/cmd/squeak/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -83,13 +82,16 @@ var rootCmd = cobra.Command{
 			config.Dialect = overrideSQLDialect
 		}
 
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("squeak")
+		outputTypeValue := cmd.Flags().Lookup("output")
+		if outputTypeValue != nil {
+			config.Output = overrideOutputType
+		}
+
 	},
 }
 
 var overrideSQLDialect lib.SQLDialect = lib.SQLite
+var overrideOutputType lib.OutputType = lib.OutputTypeSQL
 
 func main() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -106,7 +108,12 @@ func main() {
 		enumflag.New(&overrideSQLDialect, "dialect",
 			lib.SQLDialectIds, enumflag.EnumCaseInsensitive),
 		"dialect", "d",
-		"Dialect to use for the generated SQL statements")
+		"Dialect to use for the generated SQL statements (sqlite, mysql, postgresql)")
+	rootCmd.PersistentFlags().VarP(
+		enumflag.New(&overrideOutputType, "output",
+			lib.OutputTypeIds, enumflag.EnumCaseInsensitive),
+		"output", "O",
+		"Output type (SQL, CSV or SQLite)")
 
 	rootCmd.AddCommand(&generate.GenerateCmd)
 

--- a/examples/simple/users.yaml
+++ b/examples/simple/users.yaml
@@ -10,6 +10,6 @@ generate:
   tables:
     users:
       count: 1000
-  dialect: sqlite
+  dialect: mysql
   # this could be sql or db
   output: sql

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/mattn/go-isatty v0.0.14
+	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cobra v1.5.0
 	github.com/thediveo/enumflag v0.10.1

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,16 @@ module squeak
 go 1.18
 
 require (
+	github.com/mattn/go-isatty v0.0.14
 	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cobra v1.5.0
 	github.com/thediveo/enumflag v0.10.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
@@ -156,6 +158,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -168,4 +171,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/lib/config.go
+++ b/lib/config.go
@@ -1,0 +1,15 @@
+package lib
+
+type Config struct {
+	Dialect      SQLDialect
+	Output       string
+	CreateTables bool
+}
+
+func NewConfig() *Config {
+	return &Config{
+		Dialect:      SQLite,
+		Output:       "sql",
+		CreateTables: false,
+	}
+}

--- a/lib/config.go
+++ b/lib/config.go
@@ -24,12 +24,18 @@ type Config struct {
 
 func (config *Config) FromConfigFile(configFile *ConfigFile) {
 	config.CreateTables = configFile.Generate.CreateTables
-	dialectValue := enumflag.New(&config.Dialect, configFile.Generate.Dialect, SQLDialectIds, enumflag.EnumCaseInsensitive)
-	sqlDialect, castSuccessful := dialectValue.Get().(SQLDialect)
+	dialectValue := enumflag.New(&config.Dialect, "dialect", SQLDialectIds, enumflag.EnumCaseInsensitive)
+	err := dialectValue.Set(configFile.Generate.Dialect)
+	if err != nil {
+		log.Fatal().Msgf("Could not parse SQL dialect: %s", configFile.Generate.Dialect)
+	}
+
+	v := dialectValue.Get()
+	sqlDialect, castSuccessful := v.(*SQLDialect)
 	if !castSuccessful {
 		log.Fatal().Msgf("Could not parse SQL dialect: %s", configFile.Generate.Dialect)
 	}
-	config.Dialect = sqlDialect
+	config.Dialect = *sqlDialect
 	config.Output = configFile.Generate.Output
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -1,9 +1,36 @@
 package lib
 
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/thediveo/enumflag"
+	_ "gopkg.in/yaml.v3"
+)
+
+type GenerateConfig struct {
+	CreateTables bool   `yaml:"createTables"`
+	Dialect      string `yaml:"dialect"`
+	Output       string `yaml:"output"`
+}
+
+type ConfigFile struct {
+	Generate GenerateConfig `yaml:"generate"`
+}
+
 type Config struct {
+	CreateTables bool
 	Dialect      SQLDialect
 	Output       string
-	CreateTables bool
+}
+
+func (config *Config) FromConfigFile(configFile *ConfigFile) {
+	config.CreateTables = configFile.Generate.CreateTables
+	dialectValue := enumflag.New(&config.Dialect, configFile.Generate.Dialect, SQLDialectIds, enumflag.EnumCaseInsensitive)
+	sqlDialect, castSuccessful := dialectValue.Get().(SQLDialect)
+	if !castSuccessful {
+		log.Fatal().Msgf("Could not parse SQL dialect: %s", configFile.Generate.Dialect)
+	}
+	config.Dialect = sqlDialect
+	config.Output = configFile.Generate.Output
 }
 
 func NewConfig() *Config {

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -11,5 +11,3 @@ const (
 	PostGreSQL
 	MySQL
 )
-
-var CurrentSQLDialect SQLDialect

--- a/lib/sql.go
+++ b/lib/sql.go
@@ -4,6 +4,12 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
+var SQLDialectIds = map[SQLDialect][]string{
+	SQLite:     {"sqlite"},
+	MySQL:      {"mysql"},
+	PostGreSQL: {"postgresql"},
+}
+
 type SQLDialect enumflag.Flag
 
 const (


### PR DESCRIPTION
- :wrench: :sparkles: Add context to rootCmd to populate a config struct
- :wrench: :sparkles: Properly override the config file in context with flags
- :sparkles: :wrench: Add reading of config file bytes, potentially parsing
- :sparkles: :wrench: Parse the dialect flag correctly
- :sparkles: :wrench: Parse the output type flag
- :sparkles: :wrench: Correctly override with --create-tables
